### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 /.idea/
 .DS_Store
 .gitignore
+.vscode

--- a/exporter.json
+++ b/exporter.json
@@ -6,7 +6,7 @@
   "organization": "PlayStation",
   "source_dir": "src",
   "assets_dir": "assets",
-  "version": "4.7.15",
+  "version": "4.7.16",
   "usesBrands": false,
   "usesLocale": true,
   "config": {

--- a/src/page_body/structure/blocks/page_block_rich_localized_text.pr
+++ b/src/page_body/structure/blocks/page_block_rich_localized_text.pr
@@ -3,10 +3,9 @@
 
 {* Generate rich text *}
 {[ if (blueprintData.locale === "jp") ]}
-{[ let locData = ds.kvsData("localization") /]}    
-{[ let translatedText = lookupTranslatedText(locData, "jp", block) /]}
-    {[ if (translatedText !== null) ]}
-        {{ translatedText }}
+{[ let text = ds.kvsLocalizationPiece("jp", block.id) /]}    
+    {[ if (text !== null) ]}
+        {{ text }}
     {[ else ]}
         {[ inject "page_block_rich_text" context block.text /]}
     {[/]}


### PR DESCRIPTION
## Changes
  - Instead of custom `lookupTranslatedText(..)` now `ds.kvsLocalizationPiece("jp", block.id)` could be used that caches the data
  - There were other performance improvement in Pulsar, that together with this PR should make exporter way faster